### PR TITLE
Group cluster processes into `cluster:` group

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,3 +36,6 @@ sudo supervisorctl update
 
 * `./cluster.py configure` - Generate configuration files for Consul and Nomad
   and a `supervisord` configuration for the daemons.
+
+* `sudo supervisorctl [start|stop|restart] cluster:` - Start, stop and restart
+  Consul and Nomad.

--- a/cluster.py
+++ b/cluster.py
@@ -126,6 +126,9 @@ user = {username}
 command = {PATH.consul_bin} agent -config-file {PATH.consul_hcl}
 redirect_stderr = true
 autostart = {OPTIONS.supervisor_autostart}
+
+[group:cluster]
+programs = nomad,consul
 '''
 
 


### PR DESCRIPTION
Make it easy to start/stop/restart the cluster processes by grouping them into a [process group](http://supervisord.org/configuration.html#group-x-section-settings).
