### PR TITLE
Disable aws network fingerprinting

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -198,6 +198,9 @@ client {{
   meta {{
     {OPTIONS.nomad_meta}
   }}
+  options {{
+    "fingerprint.blacklist" = "env_aws"
+  }}
 }}
 
 consul {{


### PR DESCRIPTION
If `aws` is detected, the nomad `client.network_interface` setting is ignored.

I think it's best to blacklist this by default until someone wants it.