### PR TITLE
Fix tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,14 +6,20 @@ steps:
   image: alpine/flake8:3.7.7
   commands:
   - flake8
+
 - name: test on host
   image: vmck/vagrant-vmck
+  depends_on:
+  - flake8
   commands:
   - export VMCK_URL=http://$VMCK_IP:11111
   - export PROVISION=/opt/cluster/ci/test-host.sh
   - ./ci/run-vagrant-test.sh
-- name: test docker
+
+- name: test docker container
   image: vmck/vagrant-vmck
+  depends_on:
+  - flake8
   commands:
   - export VMCK_URL=http://$VMCK_IP:11111
   - export PROVISION=/opt/cluster/ci/test-docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PYTHONUNBUFFERED true
 RUN set -e \
  && apt-get update -qq \
  && apt-get install  -qq -y --no-install-recommends \
-    curl unzip libcap2-bin qemu-kvm \
+    sudo curl unzip libcap2-bin qemu-kvm dnsutils \
  && apt-get clean && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /opt/cluster
 
@@ -24,4 +24,4 @@ RUN set -e \
 
 VOLUME /opt/cluster/var
 
-ENTRYPOINT ["./cluster.py", "supervisord"]
+ENTRYPOINT ["/opt/cluster/docker-entrypoint.sh"]

--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ Wait a minute and visit:
 
 If `fabio` has been enabled in `cluster.ini`, visit:
 
-- http://10.66.60.1:9990/fabio
+- http://10.66.60.1:9990/  (Fabio UI)
 - http://10.66.60.1:9990/prometheus
 - http://10.66.60.1:9990/grafana
 - http://10.66.60.1:9990/alertmanager

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -5,7 +5,7 @@ require 'etc'
 
 Vagrant.configure("2") do |config|
   config.vm.box = "base"
-  config.vm.define "cluster-drone-" + ENV['DRONE_BUILD_NUMBER']
+  config.vm.define ENV['VMNAME']
 
   # disable implicit mount for /vagrant
   config.vm.synced_folder '.', '/vagrant', disabled: true
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
       rsync__exclude: [".vagrant/", ".git/", "__pycache__/",
                        "var/", "etc/"]
 
-  config.vm.provision "shell", inline: ENV['PROVISION']
+  config.vm.provision "shell", inline: ENV['PROVISION'], privileged: false
 
   config.vm.box = "base"
   config.nfs.functional = false

--- a/ci/run-vagrant-test.sh
+++ b/ci/run-vagrant-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
@@ -10,34 +10,34 @@ export VAGRANT_BOX_UPDATE_CHECK_DISABLE=true
 FILENAME=$(basename -- "$PROVISION")
 STEM=${FILENAME%.*}
 export VMNAME="$DRONE_REPO_NAME-$DRONE_BUILD_NUMBER-$STEM"
-set +e
-
 set +x
+
 echo
 echo '-----------------------------------------'
 echo "Starting Vagrant"
-set -x
 
-vagrant up --no-provision
+vagrant up --no-provision || echo "vagrant up failed, VM might still work"
 echo 'sudo shutdown +15' | vagrant ssh
+
+set +e
 vagrant provision
 ret=$?
+set -e
 
-set +x
 echo
 echo '-----------------------------------------'
 echo "Stats"
 
 vagrant ssh <<'EOF'
 for cmd in "uname -a" "w" "free -h" "df -h"; do
+  echo
   echo "$cmd"
   $cmd 2>&1
-  echo
 done
 EOF
 
 echo
 echo '-----------------------------------------'
 echo "Destroying Vagrant"
-vagrant destroy -f
+vagrant destroy -f || echo "vagrant destroy failed, but we don't care"
 exit $ret

--- a/ci/run-vagrant-test.sh
+++ b/ci/run-vagrant-test.sh
@@ -1,10 +1,22 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
+export VAGRANT_DOTFILE_PATH=$(mktemp -d --tmpdir VAGRANT_DOTFILE_XXXXXXXX)
+export VAGRANT_DEFAULT_PROVIDER=vmck
+export VAGRANT_CHECKPOINT_DISABLE=true
+export VAGRANT_BOX_UPDATE_CHECK_DISABLE=true
+
+FILENAME=$(basename -- "$PROVISION")
+STEM=${FILENAME%.*}
+export VMNAME="$DRONE_REPO_NAME-$DRONE_BUILD_NUMBER-$STEM"
+set +e
+
+set +x
+echo
+echo '-----------------------------------------'
 echo "Starting Vagrant"
 set -x
-set +e
 
 vagrant up --no-provision
 echo 'sudo shutdown +15' | vagrant ssh
@@ -13,16 +25,19 @@ ret=$?
 
 set +x
 echo
+echo '-----------------------------------------'
 echo "Stats"
-vagrant ssh <<EOF
-set -x
-uname -a
-w
-df -h
-free -h
+
+vagrant ssh <<'EOF'
+for cmd in "uname -a" "w" "free -h" "df -h"; do
+  echo "$cmd"
+  $cmd 2>&1
+  echo
+done
 EOF
 
 echo
+echo '-----------------------------------------'
 echo "Destroying Vagrant"
 vagrant destroy -f
 exit $ret

--- a/ci/test-common.sh
+++ b/ci/test-common.sh
@@ -2,12 +2,55 @@
 
 echo 'Redirect me to /ui/!'
 
-curl --silent 10.66.60.1:8500
-curl --silent 10.66.60.1:4646
-curl --silent 10.66.60.1:8200
+head() {
+  curl --fail --silent --show-error -I $1
+}
 
-# fabio is currently disabled by default
-#curl --silent 10.66.60.1:9990/fabio
-#curl --silent 10.66.60.1:9990/prometheus
-#curl --silent 10.66.60.1:9990/grafana
-#curl --silent 10.66.60.1:9990/alertmanager
+get() {
+  curl --fail --silent --show-error $1 > /dev/null
+}
+
+dns() {
+  DNSIP=$(dig +short @10.66.60.1 $1)
+  if [ -z $DNSIP ]; then
+    echo "DNS lookup for $1 failed"
+    exit 1
+  fi
+}
+
+
+echo "Checking consul..."
+head 10.66.60.1:8500/
+get 10.66.60.1:8500/
+get 10.66.60.1:8500/v1/status/leader
+
+echo "Checking vault..."
+head 10.66.60.1:8200/
+get 10.66.60.1:8200/
+get 10.66.60.1:8200/v1/sys/leader
+get 10.66.60.1:8200/v1/sys/seal-status
+
+echo "Checking nomad..."
+head 10.66.60.1:4646/
+get 10.66.60.1:4646/
+get 10.66.60.1:4646/v1/status/leader
+
+echo "Checking services..."
+get 10.66.60.1:9990/
+get 10.66.60.1:9990/health
+get 10.66.60.1:9990/prometheus/
+get 10.66.60.1:9990/prometheus/-/healthy/
+get 10.66.60.1:9990/alertmanager/
+get 10.66.60.1:9990/alertmanager/-/healthy/
+
+echo "Checking DNS..."
+dns consul.service.consul
+dns nomad.service.consul
+dns fabio.service.consul
+
+dns github.com
+dns liquiddemo.org
+
+# TODO: enable this check after we upgrade grafana to 6.3 (to have it pick up
+# serve_from_sub_path) Alternatively, use the `master` branch.
+#head 10.66.60.1:9990/grafana/

--- a/ci/test-docker.sh
+++ b/ci/test-docker.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -ex
 
+id $(whoami)
 cd "$( dirname "$( dirname "${BASH_SOURCE[0]}" )" )"
 
 echo "waiting for docker"
@@ -27,10 +28,16 @@ echo "running common tests"
 
 echo "stopping everything"
 docker stop cluster
-docker ps
 if [ -s "$(docker ps -q)" ]; then
     echo "some docker containers still up!"
     exit 1
 fi
+
+echo "restarting it"
+docker start cluster
+docker exec cluster ./cluster.py wait
+
+echo "running common tests (again)"
+./ci/test-common.sh
 
 echo "done!"

--- a/cluster.py
+++ b/cluster.py
@@ -314,6 +314,17 @@ def _stop():
     os.kill(pid, signal.SIGQUIT)
     log.info("SIGQUIT sent to supervisor!")
 
+    STOP_TIMEOUT = 15
+    t0 = time()
+    while time() < t0 + STOP_TIMEOUT:
+        try:
+            sleep(1)
+            supervisor_pid()
+        except subprocess.CalledProcessError:
+            log.info("Everything stopped.")
+            return
+    log.warning(f"Supervisor didn't die in {STOP_TIMEOUT} seconds...")
+
 
 @cli.command()
 def run_jobs():

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -ex
+
+cd /opt/cluster
+
+if ! id -u vagrant; then
+  echo "Setting up user and groups..."
+  groupadd -g $GROUPID vagrant
+  groupadd -g $DOCKERGROUPID hostdocker
+  useradd -u $USERID -g vagrant --create-home vagrant
+  adduser vagrant kvm
+  adduser vagrant hostdocker
+  adduser vagrant sudo
+else
+  echo "User already exists, skipping."
+fi
+
+echo "Changing permissions..."
+chown -R $USERID:$GROUPID ./etc
+chown -R $USERID:$GROUPID ./var
+
+exec sudo -nHu vagrant python3 ./cluster.py supervisord

--- a/examples/cluster.ini
+++ b/examples/cluster.ini
@@ -60,7 +60,7 @@ dev = false
 # Set the log level to DEBUG
 debug = false
 # Comma-separated list of jobs to disable from templates/*.nomad
-disable = fabio
+; disable = alertmanager,grafana
 
 # Multi-host configuration
 ; bootstrap_expect = 3

--- a/templates/alertmanager.nomad
+++ b/templates/alertmanager.nomad
@@ -19,6 +19,10 @@ job "alertmanager" {
       driver = "docker"
       config {
         image = "prom/alertmanager:v0.17.0"
+        args = [
+          "--web.route-prefix=/alertmanager",
+          "--web.external-url=http://{{OPTIONS.consul_address}}:9990/alertmanager",
+         ]
         port_map {
           http = 9093
         }
@@ -37,7 +41,7 @@ job "alertmanager" {
         tags = ["fabio-/alertmanager"]
         check {
           type     = "http"
-          path     = "/-/healthy"
+          path     = "/alertmanager/-/healthy"
           interval = "4s"
           timeout  = "2s"
         }

--- a/templates/fabio.nomad
+++ b/templates/fabio.nomad
@@ -19,8 +19,9 @@ job "fabio" {
         registry.consul.addr = {{OPTIONS.consul_address}}:8500
         registry.consul.checksRequired = all
         registry.consul.tagprefix = fabio-
-        registry.consul.register.tags = fabio-/fabio
+        registry.consul.register.tags = fabio-/
         ui.addr = ${NOMAD_ADDR_ui}
+        ui.color = green
         registry.consul.register.addr = ${NOMAD_ADDR_ui}
         proxy.addr = ${NOMAD_ADDR_lb}
         EOH

--- a/templates/grafana.nomad
+++ b/templates/grafana.nomad
@@ -20,17 +20,26 @@ job "grafana" {
     task "grafana" {
       driver = "docker"
       config {
-        image = "grafana/grafana:6.2.4"
+        image = "grafana/grafana:6.2.5"
         port_map {
           http = 3000
         }
       }
 
       env {
+        GF_DEFAULT_INSTANCE_NAME = "cluster"
         GF_LOG_LEVEL = "DEBUG"
         GF_LOG_MODE = "console"
+
         GF_PATHS_PROVISIONING = "/local/provisioning"
-        GF_DEFAULT_INSTANCE_NAME = "cluster"
+
+        GF_SECURITY_ADMIN_USER = "admin"
+        GF_SECURITY_ADMIN_PASSWORD = "admin"
+        GF_SECURITY_DISABLE_GRAVATAR = "true"
+
+        GF_SERVER_ROOT_URL = "http://{{OPTIONS.consul_address}}:9990/grafana"
+        GF_SERVER_SERVE_FROM_SUB_PATH = "true"
+        GF_SERVER_ENABLE_GZIP = "true"
 
         GF_AUTH_BASIC_ENABLED = "false"
         GF_AUTH_ANONYMOUS_ENABLED = "true"

--- a/templates/prometheus.yml
+++ b/templates/prometheus.yml
@@ -1,0 +1,38 @@
+---
+global:
+  scrape_interval:     5s
+  evaluation_interval: 5s
+
+alerting:
+  alertmanagers:
+  - consul_sd_configs:
+    - server: "{{OPTIONS.consul_address}}:8500"
+      services: ["alertmanager"]
+
+rule_files:
+  - "alert.yml"
+
+scrape_configs:
+  - job_name: "alertmanager"
+    consul_sd_configs:
+    - server: "{{OPTIONS.consul_address}}:8500"
+      services: ["alertmanager"]
+
+  - job_name: "nomad_metrics"
+    consul_sd_configs:
+    - server: "{{OPTIONS.consul_address}}:8500"
+      services: ["nomad-client", "nomad"]
+    relabel_configs:
+    - source_labels: ["__meta_consul_tags"]
+      regex: "(.*)http(.*)"
+      action: keep
+    scrape_interval: 5s
+    metrics_path: /v1/metrics
+    params:
+      format: ["prometheus"]
+
+  - job_name: "webserver"
+    consul_sd_configs:
+    - server: "{{OPTIONS.consul_address}}:8500"
+      services: ["webserver"]
+    metrics_path: /metrics

--- a/templates/prometheus_rules.yml
+++ b/templates/prometheus_rules.yml
@@ -1,0 +1,32 @@
+---
+groups:
+- name: prometheus_alerts
+  rules:
+  - alert: Consul down
+    expr: absent(up{job="consul"})
+    for: 10s
+    labels:
+      severity: critical
+    annotations:
+      description: "Consul is down!"
+  - alert: Nomad Server down
+    expr: absent(up{job="nomad"})
+    for: 10s
+    labels:
+      severity: critical
+    annotations:
+      description: "Nomad Server is down!"
+  - alert: Nomad Client down
+    expr: absent(up{job="nomad-client"})
+    for: 10s
+    labels:
+      severity: critical
+    annotations:
+      description: "Nomad Client is down!"
+  - alert: Vault is down
+    expr: absent(up{job="vault"})
+    for: 10s
+    labels:
+      severity: critical
+    annotations:
+      description: "Vault is down!"


### PR DESCRIPTION
Fixed the docker image permissions: the container is run as root, but the entrypoint will use `sudo` to drop privileges. The entrypoint also sets up an user `vagrant` with a group `vagrant` that coincide numerically with the current user. Additionally, the `vagrant` user has access to the host docker socket and the guest `kvm` group.

I've also made the two VMs run in parallel. We should probably move `ci/run-vagrant-test.sh` into `vagrant-vmck` and with minor changes (read `PLUGIN_*` plugin arguments as env vars) we can turn it into a Drone plugin.