### PR TITLE
Fix fork failures

### DIFF
--- a/bin/docker.sh
+++ b/bin/docker.sh
@@ -43,6 +43,7 @@ DOCKERGROUPID="$(getent group docker | cut -d: -f3)"
 set -x
 docker run --detach \
   --restart always \
+  --init \
   --name $name \
   --env USERID=$USERID \
   --env GROUPID=$GROUPID \

--- a/cluster.py
+++ b/cluster.py
@@ -474,8 +474,8 @@ def wait_for_supervisor():
         try:
             supervisor_pid()
             break
-        except subprocess.CalledProcessError as e:
-            log.warning(e)
+        except (OSError, subprocess.CalledProcessError) as e:
+            log.warning('waiting for supervisor: %s', e)
         sleep(2)
     else:
         raise RuntimeError('supervisord did not start')


### PR DESCRIPTION
Since we are not runnning the container with `--init`, our Python process has PID = 1 and doesn't reap zombies.

This also addresses an intermittent `OSError: no space left on device` when running `supervisord_wait`.