### PR TITLE
Examples

### DIFF
--- a/bin/docker.sh
+++ b/bin/docker.sh
@@ -6,11 +6,13 @@ rmdocker=''
 pulldocker=''
 name=cluster
 image=liquidinvestigations/cluster
+nuke=''
 while [[ $# -gt 0 ]]; do
   arg=$1
   shift
   case "$arg" in
     "--rm") rmdocker=1 ;;
+    "--nuke") nuke=1 ;;
     "--pull") pulldocker=1 ;;
     "--name") name=$1; shift ;;
     "--image") image=$1; shift ;;
@@ -29,6 +31,10 @@ if [ ! -z $rmdocker ]; then (
     docker stop $container
     docker rm $container
   ) fi
+) fi
+
+if [ ! -z $nuke ]; then (
+  sudo rm -rf var/consul var/nomad var/supervisor var/vault-secrets.ini
 ) fi
 
 USERNAME="$(whoami)"

--- a/examples/registry-systemd-override.conf
+++ b/examples/registry-systemd-override.conf
@@ -1,0 +1,5 @@
+# /etc/systemd/system/docker.service.d/override.conf
+[Service]
+Environment="GOMAXPROCS=8"
+ExecStart=
+ExecStart=/usr/bin/dockerd -H fd:// --insecure-registry 10.66.60.1:6665 --registry-mirror http://10.66.60.1:6665

--- a/examples/registry.sh
+++ b/examples/registry.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -e
 
-## Run dockerd with the following options:
-# /usr/bin/dockerd -H fd:// --insecure-registry 10.66.60.1:6665 --registry-mirror http://10.66.60.1:6665 --registry-mirror https://registry-1.docker.io
+# Run this script to start a local registry, then install
+# examples/registry-systemd-override.conf to
+# /etc/systemd/system/docker.service.d/override.conf, and restart docker:
+# sudo systemctl daemon-reload && sudo systemctl restart docker
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/..
 


### PR DESCRIPTION
* Nuke cluster state (but keep `var/registry` - the docker image local cache)
* Provide a ready to use supervisor override for docker using the local registry and the `GOMAXPROCS` fix (ref: https://github.com/kata-containers/runtime/issues/807#issuecomment-430246838)