### PR TITLE
Simplify startup, don't mount `var` or `etc`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,16 @@ RUN set -e \
  && apt-get update -qq \
  && apt-get install  -qq -y --no-install-recommends \
     sudo curl unzip libcap2-bin qemu-kvm dnsutils iptables \
+ && pip3 install pipenv \
  && apt-get clean && rm -rf /var/lib/apt/lists/* \
- && mkdir -p /app/var && mkdir -p /app/bin
+ && mkdir -p /app/var /app/etc /app/bin
 
 WORKDIR /app
-
 ADD cluster.py docker-entrypoint.sh Pipfile Pipfile.lock ./
-RUN pip3 install pipenv \
- && pipenv install --system --deploy --ignore-pipfile
-RUN ./cluster.py install \
-&& setcap cap_ipc_lock=+ep bin/vault
+
+RUN pipenv install --system --deploy --ignore-pipfile \
+ && ./cluster.py install \
+ && setcap cap_ipc_lock=+ep bin/vault
 
 ENV DOCKER_BIN=/app/bin
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN set -e \
  && mkdir -p /app/var /app/etc /app/bin
 
 WORKDIR /app
-ADD cluster.py docker-entrypoint.sh Pipfile Pipfile.lock ./
+ADD cluster.py docker-entrypoint.sh Pipfile Pipfile.lock examples/cluster.ini ./
 
 RUN pipenv install --system --deploy --ignore-pipfile \
  && ./cluster.py install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,12 @@ RUN set -e \
  && mkdir -p /app/var /app/etc /app/bin
 
 WORKDIR /app
-ADD cluster.py docker-entrypoint.sh Pipfile Pipfile.lock examples/cluster.ini ./
+ADD Pipfile Pipfile.lock ./
+RUN pipenv install --system --deploy --ignore-pipfile
 
-RUN pipenv install --system --deploy --ignore-pipfile \
- && ./cluster.py install \
- && setcap cap_ipc_lock=+ep bin/vault
+COPY . .
+ADD examples/cluster.ini ./
+RUN ./cluster.py install && setcap cap_ipc_lock=+ep bin/vault
 
 ENV DOCKER_BIN=/app/bin
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/bin/docker.sh
+++ b/bin/docker.sh
@@ -36,21 +36,13 @@ if ! getent group docker | grep -q $(whoami); then
   echo "The current user $USERNAME is not part of the docker group"
   exit 1
 fi
-USERID="$(id -u $USERNAME)"
-GROUPID="$(id -g $USERNAME)"
-DOCKERGROUPID="$(getent group docker | cut -d: -f3)"
 
 set -x
 docker run --detach \
   --restart always \
   --init \
   --name $name \
-  --env USERID=$USERID \
-  --env GROUPID=$GROUPID \
-  --env DOCKERGROUPID=$DOCKERGROUPID \
   --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume "$PWD:$PWD" \
-  --workdir "$PWD" \
   --privileged \
   --net host \
   $image

--- a/bin/docker.sh
+++ b/bin/docker.sh
@@ -32,7 +32,7 @@ if [ ! -z $rmdocker ]; then (
 ) fi
 
 USERNAME="$(whoami)"
-if ! getent group docker | grep -q $(whoami); then
+if ! docker ps; then
   echo "The current user $USERNAME is not part of the docker group"
   exit 1
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,24 +1,4 @@
 #!/bin/bash -ex
 
-echo "Running in $PWD"
-ls -alh
-
-if ! id -u vagrant; then
-  echo "Setting up user and groups..."
-  groupadd -g $GROUPID vagrant
-  groupadd -g $DOCKERGROUPID hostdocker
-  useradd -u $USERID -g vagrant --create-home vagrant
-  adduser vagrant kvm
-  adduser vagrant hostdocker
-  adduser vagrant sudo
-else
-  echo "User already exists, skipping."
-fi
-
-echo "Changing permissions..."
-chown -R $USERID:$GROUPID ./etc
-chown -R $USERID:$GROUPID ./var
-
 python3 cluster.py configure-network
-
-exec sudo -nHu vagrant DOCKER_BIN=$DOCKER_BIN python3 ./cluster.py supervisord
+exec DOCKER_BIN=$DOCKER_BIN python3 ./cluster.py supervisord

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -ex
 
 python3 cluster.py configure-network
-exec DOCKER_BIN=$DOCKER_BIN python3 ./cluster.py supervisord
+exec python3 ./cluster.py supervisord


### PR DESCRIPTION
Massively simplify the docker boilerplate. We really don't need to mount `etc` anywhere special, just `var`, and it should be outside of the git repo. How about we default to `/opt/volumes/cluster` or `/var/lib/cluster`?

edit: so cluster is needy about `cluster.ini`. All those options should be env vars for the docker container.