### PR TITLE
Fix the dirname line

### DIFF
--- a/bin/docker.sh
+++ b/bin/docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-cd "$( dirname "$( dirname "${BASH_SOURCE[0]}" )" )"
+cd "$( dirname "${BASH_SOURCE[0]}" )"/..
 
 rmdocker=''
 pulldocker=''


### PR DESCRIPTION
That one-liner is defective, see the output of `pwd`.

```shell
sendviș:cluster:% git diff
```

```diff
diff --git a/bin/docker.sh b/bin/docker.sh
index 756616a..ac47c65 100755
--- a/bin/docker.sh
+++ b/bin/docker.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 
 cd "$( dirname "$( dirname "${BASH_SOURCE[0]}" )" )"
+set -x
+pwd
+exit 0
 
 rmdocker=''
 pulldocker=''
```

```shell
sendviș:cluster:% bin/docker.sh
+ pwd
/opt/cluster
+ exit 0
sendviș:cluster:% cd bin
sendviș:bin:% ./docker.sh
+ pwd
/opt/cluster/bin
+ exit 0
```