### PR TITLE
Permissions for `vagrant` user

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,11 +11,13 @@ if ! id -u vagrant; then
   adduser vagrant kvm
   adduser vagrant hostdocker
   adduser vagrant sudo
+  adduser vagrant disk
 else
   echo "User already exists, skipping."
 fi
 
 echo "Changing permissions..."
+chown root:kvm /dev/kvm
 chown -R $USERID:$GROUPID ./etc
 chown -R $USERID:$GROUPID ./var
 


### PR DESCRIPTION
* Add to group `disk` to access device mapper block devices.
* Fix permissions for `/dev/kvm`, maybe the host and guest have
different group IDs. This does not affect the block device on the host,
only on the guest.