### PR TITLE
Only install docker-ce-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN set -e \
    $(lsb_release -cs) \
    stable" \
  && apt-get update -qq \
- && apt-get install -qq -y docker-ce docker-ce-cli containerd.io \
+ && apt-get install -qq -y docker-ce-cli \
  && apt-get clean && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /app/var && mkdir -p /app/bin
 


### PR DESCRIPTION
We don't need dockerd, in fact it causes problems with GIDs, so let's simplify.