### PR TITLE
Loki

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,9 +2,10 @@
 
 This script installs and configures [Consul][], [Vault][] and [Nomad][]. After
 those are up, we're running [dnsmasq][] to forward Consul's DNS, [Prometheus][]
-to collect Nomad stats and [Grafana][] to display them in a nice dashboard.
-It's designed to be easy to use on a fresh Linux machine, therefore it's
-somewhat opinionated.
+to collect Nomad stats, [Loki][] to collect logs, and [Grafana][] to display
+them in a nice dashboard. It also runs a local [Docker registry][] to cache
+images. It's designed to be easy to use on a fresh Linux machine, therefore
+it's somewhat opinionated.
 
 [consul]: https://www.consul.io/
 [vault]: https://www.vaultproject.io/
@@ -13,6 +14,8 @@ somewhat opinionated.
 [dnsmasq]: http://www.thekelleys.org.uk/dnsmasq/doc.html
 [Prometheus]: http://prometheus.io/
 [Grafana]: https://grafana.com/
+[Loki]: https://grafana.com/oss/loki
+[Docker registry]: https://docs.docker.com/registry/deploying/
 
 ## Quick Start (Linux)
 
@@ -255,7 +258,9 @@ We also run some jobs as services:
 
 * `prometheus` -- collects metrics from Nomad
 * `alertmanager` -- signals alerts from Prometheus
-* `grafana` -- displays dashboards with data from Prometheus
+* `grafana` -- displays dashboards with data from Prometheus and Loki
+* `loki` -- collects logs from apps
+* `registry` -- local registry to cache docker images
 
 Finally, we have one periodic job:
 

--- a/cluster.py
+++ b/cluster.py
@@ -98,8 +98,8 @@ def consul_retry_join_section(servers):
 
 
 ALL_JOBS = ['cluster-fabio', 'prometheus', 'alertmanager', 'grafana',
-            'dnsmasq', 'registry', 'docker-system-prune']
-SYSTEM_JOBS = ['dnsmasq', 'cluster-fabio']
+            'loki', 'dnsmasq', 'registry', 'docker-system-prune']
+SYSTEM_JOBS = ['dnsmasq', 'cluster-fabio', 'loki']
 
 
 def translate_job_name(option_name):

--- a/cluster.py
+++ b/cluster.py
@@ -98,7 +98,7 @@ def consul_retry_join_section(servers):
 
 
 ALL_JOBS = ['cluster-fabio', 'prometheus', 'alertmanager', 'grafana',
-            'dnsmasq', 'docker-system-prune']
+            'dnsmasq', 'registry', 'docker-system-prune']
 SYSTEM_JOBS = ['dnsmasq', 'cluster-fabio']
 
 

--- a/examples/cluster.ini
+++ b/examples/cluster.ini
@@ -77,7 +77,7 @@ debug = false
 # Comma-separated list of jobs to run from templates/*.nomad.
 # Defaults to "none", running nothing.
 # To run all jobs, set it to "all".
-run_jobs = dnsmasq,registry,fabio,prometheus,docker-system-prune
+run_jobs = dnsmasq,registry,fabio,loki,grafana,prometheus,docker-system-prune
 
 # Multi-host configuration
 ; bootstrap_expect = 3

--- a/examples/cluster.ini
+++ b/examples/cluster.ini
@@ -44,6 +44,7 @@ forward_ports = 80:80,443:443
 ; meaning_of_life = happiness
 # These flags are used by the Liquid Investigations CI.
 volumes = /opt/volumes
+cluster_volumes = /opt/cluster/var/volumes
 liquid_volumes = /opt/node/volumes
 liquid_collections = /opt/node/collections
 liquid_ingress = true
@@ -76,7 +77,7 @@ debug = false
 # Comma-separated list of jobs to run from templates/*.nomad.
 # Defaults to "none", running nothing.
 # To run all jobs, set it to "all".
-run_jobs = dnsmasq,fabio,prometheus,docker-system-prune
+run_jobs = dnsmasq,registry,fabio,prometheus,docker-system-prune
 
 # Multi-host configuration
 ; bootstrap_expect = 3

--- a/templates/grafana.nomad
+++ b/templates/grafana.nomad
@@ -49,7 +49,7 @@ job "grafana" {
         port = "http"
         tags = ["fabio-/grafana"]
         check {
-          name     = "http"
+          name     = "Grafana alive on HTTP"
           type     = "http"
           path     = "/grafana/api/health"
           interval = "4s"

--- a/templates/grafana.nomad
+++ b/templates/grafana.nomad
@@ -4,41 +4,25 @@ job "grafana" {
   priority = 90
 
   group "grafana" {
-    reschedule {
-      unlimited = true
-      attempts = 0
-      delay = "5s"
-    }
     restart {
-      attempts = 3
-      interval = "18s"
-      delay = "4s"
-      mode = "fail"
-    }
-
-    ephemeral_disk {
-      size = 500
-      sticky = true
+      attempts = 10
+      interval = "2m"
+      delay = "10s"
+      mode = "delay"
     }
 
     task "grafana" {
       driver = "docker"
       config {
-        image = "grafana/grafana:6.3.0-beta1"
+        image = "grafana/grafana:6.3.5"
         port_map {
           http = 3000
         }
       }
 
       env {
-        GF_DEFAULT_INSTANCE_NAME = "cluster"
-        GF_LOG_LEVEL = "DEBUG"
-        GF_LOG_MODE = "console"
-
         GF_PATHS_PROVISIONING = "/local/provisioning"
 
-        GF_SECURITY_ADMIN_USER = "admin"
-        GF_SECURITY_ADMIN_PASSWORD = "admin"
         GF_SECURITY_DISABLE_GRAVATAR = "true"
 
         GF_SERVER_ROOT_URL = "http://${attr.unique.network.ip-address}:9990/grafana"
@@ -56,8 +40,7 @@ job "grafana" {
         memory = 250
         network {
           mbits = 10
-          port "http" {
-          }
+          port "http" {}
         }
       }
 
@@ -66,16 +49,11 @@ job "grafana" {
         port = "http"
         tags = ["fabio-/grafana"]
         check {
-          name     = "Grafana alive on HTTP"
+          name     = "http"
           type     = "http"
           path     = "/grafana/api/health"
           interval = "4s"
           timeout  = "2s"
-          check_restart {
-            limit = 3
-            grace = "20s"
-            ignore_warnings = false
-          }
         }
       }
     }

--- a/templates/loki.nomad
+++ b/templates/loki.nomad
@@ -1,0 +1,44 @@
+job "loki" {
+  datacenters = ["dc1"]
+  type = "system"
+  priority = 95
+
+  group "loki" {
+    constraint {
+      attribute = "${meta.cluster_volumes}"
+      operator = "is_set"
+    }
+
+    restart {
+      attempts = 10
+      interval = "2m"
+      delay = "10s"
+      mode = "delay"
+    }
+
+    task "loki" {
+      driver = "docker"
+
+      config {
+        image = "grafana/loki:master"
+        volumes = [
+          "${meta.cluster_volumes}/loki:/tmp/loki",
+        ]
+        port_map {
+          http = 3100
+        }
+      }
+
+      resources {
+        cpu = 200
+        memory = 100
+        network {
+          mbits = 10
+          port "http" {
+            static = 3100
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/registry.nomad
+++ b/templates/registry.nomad
@@ -1,0 +1,76 @@
+job "registry" {
+  datacenters = ["dc1"]
+  type = "system"
+  priority = 90
+
+  group "registry" {
+    constraint {
+      attribute = "${meta.cluster_volumes}"
+      operator = "is_set"
+    }
+
+    task "registry" {
+      driver = "docker"
+
+      config {
+        image = "registry:2"
+        volumes = [
+          "local/registry-config.yml:/etc/docker/registry/config.yml:ro",
+          "${meta.cluster_volumes}/registry:/var/lib/registry",
+        ]
+        port_map {
+          http = 5000
+        }
+      }
+
+      template {
+        destination = "local/registry-config.yml"
+        data = <<-EOF
+          version: 0.1
+          log:
+            fields:
+              service: registry
+          storage:
+            cache:
+              blobdescriptor: inmemory
+            filesystem:
+              rootdirectory: /var/lib/registry
+          http:
+            addr: :5000
+            headers:
+              X-Content-Type-Options: [nosniff]
+          health:
+            storagedriver:
+              enabled: true
+              interval: 10s
+              threshold: 3
+          proxy:
+            remoteurl: https://registry-1.docker.io
+          EOF
+      }
+
+      resources {
+        cpu = 200
+        memory = 100
+        network {
+          mbits = 10
+          port "http" {
+            static = 9991
+          }
+        }
+      }
+
+      service {
+        name = "registry"
+        port = "http"
+        check {
+          name = "http"
+          type = "http"
+          path = "/"
+          interval = "4s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This runs [Loki](https://grafana.com/oss/loki) which is a log aggregator from the Grafana people. Loki runs as a system job, so we'll have one for each nomad client. Grafana needs to add all of them as data sources. Not sure if this is the smartest approach, but on a single node cluster it still does the right thing. Here is how to send logs: https://github.com/liquidinvestigations/node/pull/197

[Here](http://kowalski:9990/grafana/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bgroup%3D%5C%22authproxy%5C%22%7D%22%7D,%7B%22mode%22:%22Logs%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D) is a working example on kowalski.

~TODO: provision grafana with loki as data source~ https://github.com/liquidinvestigations/cluster/issues/83

To set up Loki as data source for Grafana, go to `http://10.66.60.1:9990/grafana/datasources/new`, select Loki, set `http://10.66.60.1:3100` as URL, and click on "Save & Test". It should display a happy `Data source connected and labels found.` message.

<img width="610" alt="Screenshot 2019-09-15 at 23 54 57" src="https://user-images.githubusercontent.com/27617/64927527-99a23200-d814-11e9-8478-47cde4b26fc3.png">
<img width="374" alt="Screenshot 2019-09-16 at 13 03 15" src="https://user-images.githubusercontent.com/27617/64949686-68f8e180-d882-11e9-83f5-c1ebdddfbf76.png">


<img width="1150" alt="Screenshot 2019-09-15 at 23 57 15" src="https://user-images.githubusercontent.com/27617/64927526-95761480-d814-11e9-8afe-bc0f0987c7ab.png">