### PR TITLE
Don't run any jobs by default

### DIFF
--- a/examples/cluster.ini
+++ b/examples/cluster.ini
@@ -77,7 +77,7 @@ debug = false
 # Comma-separated list of jobs to run from templates/*.nomad.
 # Defaults to "none", running nothing.
 # To run all jobs, set it to "all".
-run_jobs = all
+; run_jobs = all
 
 # Multi-host configuration
 ; bootstrap_expect = 3

--- a/examples/cluster.ini
+++ b/examples/cluster.ini
@@ -77,7 +77,7 @@ debug = false
 # Comma-separated list of jobs to run from templates/*.nomad.
 # Defaults to "none", running nothing.
 # To run all jobs, set it to "all".
-; run_jobs = all
+run_jobs = dnsmasq
 
 # Multi-host configuration
 ; bootstrap_expect = 3


### PR DESCRIPTION
So that we don't waste memory in low-resource vagrants
