### PR TITLE
Retention for influxdb, prometheus

### DIFF
--- a/grafana-dashboards/home.json
+++ b/grafana-dashboards/home.json
@@ -1608,7 +1608,7 @@
         "y": 24
       },
       "id": 16,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "avg": false,
         "current": false,
@@ -1803,7 +1803,7 @@
       }
     }
   ],
-  "refresh": "10s",
+  "refresh": "30s",
   "schemaVersion": 19,
   "style": "dark",
   "tags": [],
@@ -1815,10 +1815,8 @@
     "to": "now"
   },
   "timepicker": {
-    "nowDelay": "10s",
+    "nowDelay": "30s",
     "refresh_intervals": [
-      "5s",
-      "10s",
       "30s",
       "1m",
       "5m",

--- a/grafana-dashboards/hoover-es.json
+++ b/grafana-dashboards/hoover-es.json
@@ -583,7 +583,7 @@
         "y": 5
       },
       "id": 52,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -810,7 +810,7 @@
       },
       "hideTimeOverride": false,
       "id": 55,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -2293,7 +2293,7 @@
         "y": 32
       },
       "id": 67,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -5893,7 +5893,7 @@
         "y": 76
       },
       "id": 102,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -6063,7 +6063,7 @@
         "y": 85
       },
       "id": 89,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -6402,7 +6402,7 @@
         "y": 85
       },
       "id": 90,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -6594,7 +6594,7 @@
         "y": 95
       },
       "id": 93,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -7738,7 +7738,7 @@
         "y": 105
       },
       "id": 98,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -7983,7 +7983,7 @@
         "y": 105
       },
       "id": 103,
-      "interval": "10s",
+      "interval": "30s",
       "legend": {
         "alignAsTable": true,
         "avg": true,

--- a/grafana-dashboards/telegraf-system.json
+++ b/grafana-dashboards/telegraf-system.json
@@ -4710,7 +4710,7 @@
       }
     }
   ],
-  "refresh": "10s",
+  "refresh": "30s",
   "schemaVersion": 19,
   "style": "dark",
   "tags": [

--- a/templates/influxdb.nomad
+++ b/templates/influxdb.nomad
@@ -19,6 +19,7 @@ job "influxdb" {
         }
         volumes = [
           "${meta.cluster_volumes}/influxdb:/var/lib/influxdb",
+          "local/telegraf-create-retention.iql:/docker-entrypoint-initdb.d/telegraf-create-retention.iql:ro",
         ]
       }
 
@@ -33,6 +34,13 @@ job "influxdb" {
           mbits = 1
           port "http" {}
         }
+      }
+
+      template {
+        destination = "local/telegraf-create-retention.iql"
+        data = <<-EOH
+        ALTER RETENTION POLICY "autogen" ON "telegraf" DURATION 32d SHARD DURATION 1d DEFAULT
+        EOH
       }
 
       service {

--- a/templates/prometheus.nomad
+++ b/templates/prometheus.nomad
@@ -49,6 +49,7 @@ job "prometheus" {
           "--web.route-prefix=/prometheus",
           "--web.external-url=http://${attr.unique.network.ip-address}:9990/prometheus",
           "--config.file=/etc/prometheus/prometheus.yml",
+          "--storage.tsdb.retention.time=32d",
          ]
         volumes = [
           "local/prometheus_rules.yml:/etc/prometheus/prometheus_rules.yml",

--- a/templates/telegraf.nomad
+++ b/templates/telegraf.nomad
@@ -28,8 +28,8 @@ job "telegraf" {
         destination = "local/telegraf.conf"
         data = <<-EOF
           [agent]
-            interval = "10s"
-            flush_interval = "10s"
+            interval = "20s"
+            flush_interval = "20s"
             omit_hostname = false
             debug = false
             quiet = false

--- a/templates/telegraf.nomad
+++ b/templates/telegraf.nomad
@@ -28,8 +28,8 @@ job "telegraf" {
         destination = "local/telegraf.conf"
         data = <<-EOF
           [agent]
-            interval = "20s"
-            flush_interval = "20s"
+            interval = "30s"
+            flush_interval = "30s"
             omit_hostname = false
             debug = false
             quiet = false


### PR DESCRIPTION
The prometheus default retention is `15d` (too small) and for influxdb it's `inf` (too large).

This does not change the retention policy for existing influxdb instances. To change those, use this wonderful one-liner:

```
docker exec -it $(docker ps -q -f ancestor=influxdb:1.5-alpine) bash -c "cat /docker-entrypoint-initdb.d/telegraf-create-retention.iql | influx"
```