### PR TITLE
Switch from curl to urllib module

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -222,7 +222,12 @@ class JsonApi:
 
 
 def download(url, path):
-    run(f'curl -Ls "{url}" -o "{path}"')
+    log.debug(f'+ downloading from {url} to {path}')
+    with urlopen(url) as res:
+        if res.status != 200:
+            return
+        with open(path, 'wb') as f:
+            f.write(res.read())
 
 
 def unzip(zip_path, **kwargs):


### PR DESCRIPTION
I changed the download function so it uses the urllib.request module. I also added a log.debug() message to preserve the previous behaviour of the function.

Closes #13 

As for the unzip command, the zipfile module doesn't preserve file permissions.

